### PR TITLE
Corrects the format of json request.

### DIFF
--- a/src/main/java/Controller/CreateGroupController.java
+++ b/src/main/java/Controller/CreateGroupController.java
@@ -126,7 +126,7 @@ public class CreateGroupController implements Initializable {
         JSONObject androidInfo = new JSONObject();
         androidInfo.put("androidPackageName", Data.data.getANDROID_APP_PACKAGE_NAME());
         JSONObject dynamicLinkInfo = new JSONObject();
-        dynamicLinkInfo.put("dynamicLinkDomain", Data.data.getDYNAMIC_LINK_DOMAIN());
+        dynamicLinkInfo.put("domainUriPrefix", Data.data.getDYNAMIC_LINK_DOMAIN());
         dynamicLinkInfo.put("link", "https://odknotificatons?id="+groupId);
         dynamicLinkInfo.put("androidInfo", androidInfo);
 


### PR DESCRIPTION
Closes #37 
Replacing `dynamicLinkDomain` with `domainUriPrefix` at ```CreateGroupController:129``` solves this problem.
Note: Can be tested only after adding sqlite dependency #36.
See the documentation, for more info: https://firebase.google.com/docs/dynamic-links/rest
