### PR TITLE
Solved crashing of app at the time of sending second notification.

### DIFF
--- a/src/main/java/Controller/CreateNotificationController.java
+++ b/src/main/java/Controller/CreateNotificationController.java
@@ -83,7 +83,6 @@ public class CreateNotificationController implements Initializable {
 
         if(!(titleStr.isEmpty() && messageStr.isEmpty())) {
             progressIndicator.setVisible(true);
-            progressIndicator.setProgress(-1.0f);
             send_button.setDisable(true);
             Group selected = comboBox.getSelectionModel().getSelectedItem();
             Task<Void> task = new Task<Void>() {
@@ -124,8 +123,6 @@ public class CreateNotificationController implements Initializable {
                 send_button.setDisable(false);
                 title_field.clear();
                 message_field.clear();
-                progressIndicator.progressProperty().unbind();
-                statusLabel.textProperty().unbind();
             });
 
             progressIndicator.progressProperty().bind(task.progressProperty());

--- a/src/main/java/Controller/CreateNotificationController.java
+++ b/src/main/java/Controller/CreateNotificationController.java
@@ -124,6 +124,8 @@ public class CreateNotificationController implements Initializable {
                 send_button.setDisable(false);
                 title_field.clear();
                 message_field.clear();
+                progressIndicator.progressProperty().unbind();
+                statusLabel.textProperty().unbind();
             });
 
             progressIndicator.progressProperty().bind(task.progressProperty());


### PR DESCRIPTION
Closes #22 

Actually, on clicking send button code tries to change values of progressIndicator and statuslabel which are already bind. Unbinding them after sending message successfully solves this issue.
The error log is:  
`Caused by: java.lang.RuntimeException: ProgressIndicator.progress : A bound value cannot be set.
	at javafx.beans.property.DoublePropertyBase.set(DoublePropertyBase.java:143)
	at javafx.scene.control.ProgressIndicator.setProgress(ProgressIndicator.java:163)
	at Controller.CreateNotificationController.sendButtonClicked(CreateNotificationController.java:86)
	... 41 more`
Note: Can be tested only after merging #38  and #36 