### PR TITLE
Return to Login page after settings are saved successfully

### DIFF
--- a/src/main/java/Controller/SettingsController.java
+++ b/src/main/java/Controller/SettingsController.java
@@ -11,6 +11,7 @@ import java.net.URL;
 import java.util.ResourceBundle;
 
 public class SettingsController implements Initializable {
+    public static LoginPageController loginPageController;
     public TextField serviceAccountKeyPathField;
     public TextField webAPIKeyField;
     public TextField firebaseDatabaseURLField;
@@ -62,5 +63,6 @@ public class SettingsController implements Initializable {
         Data.data.setSYNC_CLIENT_URL(syncClientURLField.getText());
         Data.data.setFIREBASE_DATABASE_URL(firebaseDatabaseURLField.getText());
         Data.data.saveKeys();
+        loginPageController.switchToLoginPage();
     }
 }

--- a/src/main/java/Launch.java
+++ b/src/main/java/Launch.java
@@ -3,6 +3,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import Controller.SettingsController;
 
 public class Launch extends Application {
 
@@ -12,7 +13,9 @@ public class Launch extends Application {
 
     @Override
     public void start(Stage primaryStage) throws Exception {
-        Parent root = FXMLLoader.load(getClass().getResource("fxml/LoginPage.fxml"));
+        FXMLLoader loader= new FXMLLoader(getClass().getResource("fxml/LoginPage.fxml"));
+        Parent root = loader.load();
+        SettingsController.loginPageController=loader.getController();
         primaryStage.setTitle("ODK-X Notify Admin Panel");
         primaryStage.setScene(new Scene(root,740,420));
         primaryStage.show();


### PR DESCRIPTION
Currently clicking on save doesn't close the settings page and user has to manually close it . 
This pull request is for clicking on save ,saving settings the settings screen closes and login page opens again . 