### PR TITLE
Display the new window(Notification Response) over the existing window

### DIFF
--- a/src/main/java/Controller/NotificationGroupController.java
+++ b/src/main/java/Controller/NotificationGroupController.java
@@ -79,6 +79,7 @@ public class NotificationGroupController implements Initializable {
                     fxmlLoader.setController(new NotificationResponseController(clickedRow));
                     Stage stage = new Stage();
                     stage.setTitle("Notification Responses");
+                    stage.setAlwaysOnTop(true);
                     try {
                         stage.setScene(new Scene(fxmlLoader.load(),600,400));
                     } catch (IOException e) {
@@ -89,7 +90,7 @@ public class NotificationGroupController implements Initializable {
             });
             return row ;
         });
-
+.
     }
 
     public void copyToClipboardClicked(MouseEvent mouseEvent) {


### PR DESCRIPTION
The new window is not displayed after opening . It is displayed behind the existing window because the setAlwaysOnTop() property was not setup. This pull request is to correct that