### PR TITLE
Check for Group selection before making call to firebase

### DIFF
--- a/src/main/java/Controller/CreateNotificationController.java
+++ b/src/main/java/Controller/CreateNotificationController.java
@@ -81,12 +81,12 @@ public class CreateNotificationController implements Initializable {
     public void sendButtonClicked() {
         String titleStr = title_field.getText();
         String messageStr = message_field.getText();
+        Group selected = comboBox.getSelectionModel().getSelectedItem();
 
-        if(!(titleStr.isEmpty() && messageStr.isEmpty())) {
+        if(!(titleStr.isEmpty() && messageStr.isEmpty()) && !selected.equals(null)) {
             progressIndicator.setVisible(true);
             statusLabel.setVisible(true);
             send_button.setDisable(true);
-            Group selected = comboBox.getSelectionModel().getSelectedItem();
             String type = ((RadioButton)toggleGroup.getSelectedToggle()).getText();
             DatabaseReference notifRef = FirebaseDatabase.getInstance().getReference("/notifications").push();
             String notif_id = notifRef.getKey();


### PR DESCRIPTION
Group is a mandatory field for sending notification , currently if group is not selected it is not checked and when send is clicked , the send button is set to invisible and the call leads to a dead lock in application. This code ensures that group is not null before making the call