### PR TITLE
Add feature to send image along with notification

### DIFF
--- a/src/main/java/Controller/LoginFormController.java
+++ b/src/main/java/Controller/LoginFormController.java
@@ -142,9 +142,10 @@ public class LoginFormController implements Initializable {
         Data data = new Data();
         FileInputStream serviceAccount = new FileInputStream(FIREBASE_KEYS_FILE_NAME);
         FirebaseOptions options = new FirebaseOptions.Builder()
-                 .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                 .setDatabaseUrl(data.getFIREBASE_DATABASE_URL())
-                 .build();
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .setDatabaseUrl(data.getFIREBASE_DATABASE_URL())
+                .setStorageBucket(data.getSTORAGE_BUCKET())
+                .build();
         FirebaseApp.initializeApp(options);
 
     }

--- a/src/main/java/Controller/SettingsController.java
+++ b/src/main/java/Controller/SettingsController.java
@@ -19,6 +19,7 @@ public class SettingsController implements Initializable {
     public TextField packageNameField;
     public ImageView folderIcon;
     public TextField syncClientURLField;
+    public TextField storageBucketField;
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         readKeyData();
@@ -33,6 +34,7 @@ public class SettingsController implements Initializable {
        dynamicLinkDomainField.setText(Data.data.getDYNAMIC_LINK_DOMAIN());
        packageNameField.setText(Data.data.getANDROID_APP_PACKAGE_NAME());
        syncClientURLField.setText(Data.data.getSYNC_CLIENT_URL());
+       storageBucketField.setText(Data.data.getSTORAGE_BUCKET());
        System.out.print(Data.data);
     }
 
@@ -62,6 +64,7 @@ public class SettingsController implements Initializable {
         Data.data.setWEB_API_KEY(webAPIKeyField.getText());
         Data.data.setSYNC_CLIENT_URL(syncClientURLField.getText());
         Data.data.setFIREBASE_DATABASE_URL(firebaseDatabaseURLField.getText());
+        Data.data.setSTORAGE_BUCKET(storageBucketField.getText());
         Data.data.saveKeys();
         loginPageController.switchToLoginPage();
     }

--- a/src/main/java/Data/Data.java
+++ b/src/main/java/Data/Data.java
@@ -16,6 +16,7 @@ public class Data {
     private String SERVICE_ACCOUNT_KEY_PATH;
     private String SYNC_CLIENT_URL;
     private String FIREBASE_DATABASE_URL;
+    private String STORAGE_BUCKET;
     private static final String FILE_NAME = "keys.json";
     public static final String FIREBASE_KEYS_FILE_NAME = "FirebaseKeys.json";
 
@@ -32,6 +33,7 @@ public class Data {
               setANDROID_APP_PACKAGE_NAME(mainObject.getString("packageName"));
               setSYNC_CLIENT_URL(mainObject.getString("syncClientURL"));
               setFIREBASE_DATABASE_URL(mainObject.getString("firebaseDatabaseURL"));
+              setSTORAGE_BUCKET(mainObject.getString("storageBucket"));
           }catch (Exception e){
               e.printStackTrace();
           }
@@ -48,6 +50,7 @@ public class Data {
       obj.put("packageName", ANDROID_APP_PACKAGE_NAME);
       obj.put("syncClientURL", SYNC_CLIENT_URL);
       obj.put("firebaseDatabaseURL",FIREBASE_DATABASE_URL);
+      obj.put("storageBucket",STORAGE_BUCKET);
 
       try {
           BufferedWriter out = new BufferedWriter(new FileWriter(FILE_NAME));
@@ -139,7 +142,12 @@ public class Data {
     public void setFIREBASE_DATABASE_URL(String FIREBASE_DATABASE_URL) {
         this.FIREBASE_DATABASE_URL = FIREBASE_DATABASE_URL;
     }
-
+    public String getSTORAGE_BUCKET(){
+       return STORAGE_BUCKET;
+    }
+    public void setSTORAGE_BUCKET(String STORAGE_BUCKET){
+       this.STORAGE_BUCKET = STORAGE_BUCKET;
+    }
     @Override
     public String toString() {
         return "Data{" +
@@ -152,6 +160,7 @@ public class Data {
                 ", DYNAMIC_LINK_DOMAIN='" + DYNAMIC_LINK_DOMAIN + '\'' +
                 ", SERVICE_ACCOUNT_KEY_PATH='" + SERVICE_ACCOUNT_KEY_PATH + '\'' +
                 ", SYNC_CLIENT_URL='" + SYNC_CLIENT_URL + '\'' +
+                ", STORAGE_BUCKET='" + STORAGE_BUCKET + '\'' +
                 '}';
     }
 }

--- a/src/main/java/Launch.java
+++ b/src/main/java/Launch.java
@@ -17,7 +17,7 @@ public class Launch extends Application {
         Parent root = loader.load();
         SettingsController.loginPageController=loader.getController();
         primaryStage.setTitle("ODK-X Notify Admin Panel");
-        primaryStage.setScene(new Scene(root,740,420));
+        primaryStage.setScene(new Scene(root,740,520));
         primaryStage.show();
 
     }

--- a/src/main/resources/fxml/CreateNotification.fxml
+++ b/src/main/resources/fxml/CreateNotification.fxml
@@ -34,7 +34,7 @@
             <HBox.margin>
                 <Insets left="20.0" right="20.0" />
             </HBox.margin>
-            <Button fx:id="image_selector" mnemonicParsing="false" prefHeight="31.0" prefWidth="60.0" text="Select image" />
+            <Button fx:id="image_selector_button" mnemonicParsing="false" prefHeight="31.0" prefWidth="60.0" text="Select image" />
         </HBox>
         <HBox layoutX="30.0" layoutY="144.0">
             <VBox.margin>

--- a/src/main/resources/fxml/CreateNotification.fxml
+++ b/src/main/resources/fxml/CreateNotification.fxml
@@ -24,7 +24,18 @@
             </VBox.margin>
         </Label>
         <TextField fx:id="message_field" prefHeight="31.0" prefWidth="450.0" />
-
+        <Label text="Image">
+            <VBox.margin>
+                <Insets top="10.0" />
+            </VBox.margin>
+        </Label>
+        <HBox alignment="CENTER_LEFT" prefHeight="60.0" prefWidth="560.0">
+            <TextField fx:id="image_path" prefHeight="31.0" prefWidth="450.0" />
+            <HBox.margin>
+                <Insets left="20.0" right="20.0" />
+            </HBox.margin>
+            <Button fx:id="image_selector" mnemonicParsing="false" prefHeight="31.0" prefWidth="60.0" text="Select image" />
+        </HBox>
         <HBox layoutX="30.0" layoutY="144.0">
             <VBox.margin>
                 <Insets top="20.0" />

--- a/src/main/resources/fxml/Settings.fxml
+++ b/src/main/resources/fxml/Settings.fxml
@@ -83,6 +83,17 @@
             </VBox.margin>
             <TextField fx:id="packageNameField" prefHeight="31.0" prefWidth="400.0"/>
         </HBox>
+        <Label text="Storage Bucket ">
+            <VBox.margin>
+                <Insets top="10.0"/>
+            </VBox.margin>
+        </Label>
+        <HBox>
+            <VBox.margin>
+                <Insets top="5.0"/>
+            </VBox.margin>
+            <TextField fx:id="storageBucketField" prefHeight="31.0" prefWidth="400.0"/>
+        </HBox>
         <Button mnemonicParsing="false" onMouseClicked="#saveButtonClicked" text="Save">
             <VBox.margin>
                 <Insets bottom="10.0" right="10.0" top="10.0"/>


### PR DESCRIPTION
create notification page has a new field with file chooser which helps is selecting an image from local storage to send it along with notification. 
Firebase storage is used to store the image . The Firebase storage link for the image is sent along with the message with key "img" . The same key is used to retrieve the image in the android application skunkworks bat. Another Pull request in skunkworks-bat has been made in to include the new feature.